### PR TITLE
bind and expose ssh_userauth_password

### DIFF
--- a/examples/run-command.p6
+++ b/examples/run-command.p6
@@ -1,7 +1,7 @@
 use SSH::LibSSH;
 
-sub MAIN(Str $host, Str $user, Str :$private-key-file, *@command) {
-    my $session = await SSH::LibSSH.connect(:$host, :$user, :$private-key-file);
+sub MAIN(Str $host, Str $user, Int :$port = 22, Str :$password, Str :$private-key-file, *@command) {
+    my $session = await SSH::LibSSH.connect(:$host, :$user, :$port, :$private-key-file, :$password);
     my $channel = await $session.execute(@command.join(' '));
     my $exit-code;
     react {

--- a/examples/run-command.p6
+++ b/examples/run-command.p6
@@ -10,10 +10,10 @@ sub MAIN(Str $host, Str $user, Int :$port = 22, Str :$password, Str :$private-ke
                 $channel.close-stdin;
             }
         }
-        whenever $channel.stdout -> $chars {
+        whenever $channel.stdout(:enc<utf8>) -> $chars {
             $*OUT.print: $chars;
         }
-        whenever $channel.stderr -> $chars {
+        whenever $channel.stderr(:enc<utf8>) -> $chars {
             $*ERR.print: $chars;
         }
         whenever $channel.exit -> $code {

--- a/examples/scp-download.p6
+++ b/examples/scp-download.p6
@@ -1,7 +1,7 @@
 use SSH::LibSSH;
 
-sub MAIN($host, $user, $remote, $local) {
-    my $session = await SSH::LibSSH.connect(:$host, :$user);
+sub MAIN($host, $user, $remote, $local, Int :$port, Str :$password) {
+    my $session = await SSH::LibSSH.connect(:$host, :$user, :$port, :$password);
     await $session.scp-download($remote, $local);
     $session.close;
 }

--- a/examples/scp-upload.p6
+++ b/examples/scp-upload.p6
@@ -1,7 +1,7 @@
 use SSH::LibSSH;
 
-sub MAIN($host, $user, $local, $remote) {
-    my $session = await SSH::LibSSH.connect(:$host, :$user);
+sub MAIN($host, $user, $local, $remote, Int :$port, Str :$password) {
+    my $session = await SSH::LibSSH.connect(:$host, :$user, :$port, :$password);
     await $session.scp-upload($local, $remote);
     $session.close;
 }

--- a/lib/SSH/LibSSH.pm6
+++ b/lib/SSH/LibSSH.pm6
@@ -138,7 +138,7 @@ class SSH::LibSSH {
         has Str $.host;
         has Int $.port;
         has Str $.user;
-        has Str $.password;
+        has Str $!password;
         has Str $.private-key-file;
         has LogLevel $!log-level;
         has &.on-server-unknown;
@@ -356,7 +356,7 @@ class SSH::LibSSH {
                 $v.keep(self);
             }
             else {
-                if $method eq "key" and defined $.password {
+                if $method eq "key" and defined $!password {
                     # Public Key authentication failed. We'll try using a password now.
                     self!connect-auth-user-password($v);
                 } else {
@@ -368,7 +368,7 @@ class SSH::LibSSH {
 
         method !connect-auth-user-password($v) {
             given $!session-handle -> $s {
-                my &auth-function = { ssh_userauth_password($s, Str, $.password) }
+                my &auth-function = { ssh_userauth_password($s, Str, $!password) }
                 my $auth-outcome = SSHAuth(error-check($s, auth-function()));
                 if $auth-outcome != SSH_AUTH_AGAIN {
                     self!process-auth-outcome($auth-outcome, $v, :method<password>);

--- a/lib/SSH/LibSSH/Raw.pm6
+++ b/lib/SSH/LibSSH/Raw.pm6
@@ -79,6 +79,8 @@ sub ssh_pki_import_privkey_file(Str, Str, Pointer, Pointer, CArray[SSHKey])
 sub ssh_userauth_publickey(SSHSession, Str, SSHKey) returns int32
     is native(libssh) is export {*}
 sub ssh_key_free(SSHKey) is native(libssh) is export {*}
+sub ssh_userauth_password(SSHSession, Str, Str) returns int32
+    is native(libssh) is export {*}
 
 my class SSHEvent is repr('CPointer') is export {}
 sub ssh_event_new() returns SSHEvent is native(libssh) is export {*}


### PR DESCRIPTION
Gives the Session class a :$password argument.
Also sets up the examples to allow passing a password, as well as a port.

The Session will always try either ssh_userauth_publickey or ssh_userauth_publickey_auto (depending on whether a :$key was supplied or not) and then try using a password (if one was set).