### PR TITLE
Fix error-check sub not handling SSH_ERROR + add method for interactive shell

### DIFF
--- a/lib/SSH/LibSSH.pm6
+++ b/lib/SSH/LibSSH.pm6
@@ -29,17 +29,19 @@ class X::SSH::LibSSH::Error is Exception {
 }
 
 class SSH::LibSSH {
-    multi sub error-check($what, $result) {
-        if $result == -1 {
+    multi sub error-check($what, Int $result) returns int32 {
+        my int32 $res = $result;
+        if $res == SSH_ERROR {
             die X::SSH::LibSSH::Error.new(message => "Failed to $what");
         }
-        $result
+        $res
     }
-    multi sub error-check(SSHSession $s, $result) {
-        if $result == -1 {
+    multi sub error-check(SSHSession $s, Int $result) returns int32 {
+        my int32 $res = $result;
+        if $res == SSH_ERROR {
             die X::SSH::LibSSH::Error.new(message => ssh_get_error($s));
         }
-        $result
+        $res
     }
 
     # We use libssh exclusively in non-blocking mode. A single event loop

--- a/lib/SSH/LibSSH.pm6
+++ b/lib/SSH/LibSSH.pm6
@@ -973,7 +973,7 @@ class SSH::LibSSH {
             given get-event-loop() -> $loop {
                 $loop.run-on-loop: {
                     $loop.add-poller: -> $remove is rw {
-                        if $!stdout-eof && $!stderr-eof {
+                        if $!stdout-eof || $!stderr-eof {
                             my $exit = ssh_channel_get_exit_status($!channel-handle);
                             if $exit >= 0 {
                                 $remove = True;

--- a/lib/SSH/LibSSH/Raw.pm6
+++ b/lib/SSH/LibSSH/Raw.pm6
@@ -36,6 +36,12 @@ sub load-windows-dependencies(--> Nil) {
     try load-libeay32();
 }
 
+# Error return codes
+constant SSH_OK     is export = 0;     # /* No error */
+constant SSH_ERROR  is export = -1;    # /* Error of some kind */
+constant SSH_AGAIN  is export = -2;    # /* The nonblocking call must be repeated */
+constant SSH_EOF    is export = -127;  # /* We have already a eof */
+
 my class SSHSession is repr('CPointer') is export {}
 my enum SSHSessionOptions is export <
     SSH_OPTIONS_HOST

--- a/lib/SSH/LibSSH/Raw.pm6
+++ b/lib/SSH/LibSSH/Raw.pm6
@@ -132,8 +132,13 @@ my class SSHChannel is repr('CPointer') is export {}
 sub ssh_channel_new(SSHSession) returns SSHChannel is native(&libssh) is export {*}
 sub ssh_channel_free(SSHChannel) is native(&libssh) is export {*}
 sub ssh_channel_open_session(SSHChannel) returns int32 is native(&libssh) is export {*}
+sub ssh_channel_is_open(SSHChannel) returns int32 is native(&libssh) is export {*}
 sub ssh_channel_close(SSHChannel) returns int32 is native(&libssh) is export {*}
 sub ssh_channel_request_exec(SSHChannel, Str) returns int32 is native(&libssh) is export {*}
+sub ssh_channel_request_pty(SSHChannel) returns int32 is native(&libssh) is export {*}
+sub ssh_channel_request_pty_size(SSHChannel, Str, int32, int32) returns int32 is native(&libssh) is export {*}
+sub ssh_channel_change_pty_size(SSHChannel, int32, int32) returns int32 is native(&libssh) is export {*}
+sub ssh_channel_request_shell(SSHChannel) returns int32 is native(&libssh) is export {*}
 sub ssh_channel_read_nonblocking(SSHChannel, Buf, uint32, int32) returns int32
     is native(&libssh) is export {*}
 sub ssh_channel_is_eof(SSHChannel) returns int32 is native(&libssh) is export {*}


### PR DESCRIPTION
The problem with error-check is weird. For example ssh_channel_open_session() returns int32 but in method dispatch comes as a Int and wrong value ( instead of -1 ) and so errors are ignored.