### PR TITLE
Fix zef build error on non-Win boxes

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -6,7 +6,7 @@ class Build {
     method build($workdir) {
         # We only have a .dll file bundled on Windows; non-Windows is assumed
         # to have a libssh already.
-        return unless $*DISTRO.is-win;
+        return True unless $*DISTRO.is-win;
 
         my constant @files = "ssh.dll", "libeay32.dll", "msvcr110.dll";
         my constant @hashes =
@@ -37,5 +37,7 @@ class Build {
                 die "Bad download of $file (got: $got-hash; expected: $hash)";
             }
         }
+
+        return True;
     }
 }


### PR DESCRIPTION
Zef fails to Build module due to this:

```
Building with plugin: Zef::Service::Shell::LegacyBuild+{<anon|1>}
Command: /home/cono/work/rakudo/install/bin/perl6 -Ilib -I/home/cono/.zef/store/p6-concurrent-progress.git/2b5652b679c2096fe8549913013fcb04a086289f/lib -I/home/cono/.zef/store/p6-test-scheduler.git/37e80685b682f65b6c01d10f74469a4db1c93b29/lib -e require '/home/cono/.zef/store/p6-ssh-libssh.git/69aea116df75f4281d04bd3bb7324eef4b57725f/Build.pm'; ::('Build').new.build('/home/cono/.zef/store/p6-ssh-libssh.git/69aea116df75f4281d04bd3bb7324eef4b57725f') ?? exit(0) !! exit(1);
===> Building [FAIL]: SSH::LibSSH
```