### PR TITLE
LibSSH: default-server-unknown: Correct unexpected behavior in prompted action

### DIFF
--- a/lib/SSH/LibSSH.rakumod
+++ b/lib/SSH/LibSSH.rakumod
@@ -216,9 +216,9 @@ class SSH::LibSSH {
         sub default-server-unknown($handler) {
             say "This server is unknown. It presented the public key hash:";
             say $handler.hash;
-            given prompt("Do you want to accpet it (yes/once/NO)?") {
+            given prompt("Do you want to accept it (yes/once/NO)?") {
                 when /:i ^ y[es] $/ { $handler.accept-and-save() }
-                when /:i ^ n[o] $/ { $handler.accept-this-time() }
+                when /:i ^ o[nce] $/ { $handler.accept-this-time() }
                 default { $handler.decline() }
             }
         }


### PR DESCRIPTION
Fix typo in prompt, change handler to call accept-this-time when the user replies with "once" instead of declining (and also decline if the user replies with "no" instead of calling accept-this-time).